### PR TITLE
Image from graph

### DIFF
--- a/examples/Emotions.ipynb
+++ b/examples/Emotions.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +197,28 @@
     }
    ],
    "source": [
-    "g_img = llm_mri.get_graph_image(category=0)\n",
+    "g = llm_mri.get_graph()\n",
+    "\n",
+    "g_img = llm_mri.get_graph_image(g)\n",
+    "plt.box(False)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g_false = llm_mri.get_graph(category=0)\n",
+    "g_true = llm_mri.get_graph(category=1)\n",
+    "g_composed = nx.compose(g_true, g_false)\n",
+    "\n",
+    "duplicates = list(set(g_true.edges) & set(g_false.edges))\n",
+    "for e in duplicates : g_composed.edges[e]['label'] = 2 \n",
+    "\n",
+    "\n",
+    "g_composed_img = llm_mri.get_graph_image(g_composed)\n",
     "plt.box(False)\n",
     "plt.show()"
    ]

--- a/examples/FakeNews.py
+++ b/examples/FakeNews.py
@@ -33,7 +33,20 @@ plt.show()
 g = llm_mri.get_graph(category=0) # Getting the graph for a designed category
 
 # Getting the image of Graph representation of activations
-g_img = llm_mri.get_graph_image(category=0) # Getting the graph image for a determined category
+g_img = llm_mri.get_graph_image(g) # Getting the graph image for a determined category
 plt.box(False)
 plt.show()
 
+# Getting activations of different times in a same Graphs
+g_false = llm_mri.get_graph(category=0)
+g_true = llm_mri.get_graph(category=1)
+g_composed = nx.compose(g_true, g_false)
+
+# Marking repeated edges
+duplicates = list(set(g_true.edges) & set(g_false.edges))
+for e in duplicates : g_composed.edges[e]['label'] = 2 
+
+# Generating image of composed graph
+g_composed_img = llm_mri.get_graph_image(g_composed)
+plt.box(False)
+plt.show()

--- a/src/LLM_MRI.py
+++ b/src/LLM_MRI.py
@@ -145,38 +145,36 @@ class LLM_MRI:
         else:
             return ['lightblue']
 
-    def get_graph_image(self, category:int):
+    def get_graph_image(self, G):
         '''
         Function that displays the pandas edgelist (graph representation) for the network region activations,
-         for a given label (category) passed as a parameter.
+         for a given graph passed as a parameter.
         '''
 
-        g = self.get_graph(category)
+        widths = nx.get_edge_attributes(G, 'weight')
+        nodelist = G.nodes()
 
-        widths = nx.get_edge_attributes(g, 'weight')
-        nodelist = g.nodes()
-
-        pos = graphviz_layout(g, prog="dot")
+        pos = graphviz_layout(G, prog="dot")
 
         fig = plt.figure(figsize=(25,6))
 
-        edge_colors = self.generate_graph_edge_colors(g)
+        edge_colors = self.generate_graph_edge_colors(G)
 
-        nx.draw(g, pos, with_labels=True, node_size=2, node_color="skyblue", node_shape="o", alpha=0.9, linewidths=20)
+        nx.draw(G, pos, with_labels=True, node_size=2, node_color="skyblue", node_shape="o", alpha=0.9, linewidths=20)
 
-        nx.draw_networkx_nodes(g,pos,
+        nx.draw_networkx_nodes(G,pos,
                             nodelist=nodelist,
                             node_size=150,
                             node_color='grey',
                             alpha=0.8)
 
-        nx.draw_networkx_edges(g,pos,
+        nx.draw_networkx_edges(G,pos,
                             edgelist = widths.keys(),
                             width=list(widths.values()),
                             edge_color=edge_colors,
                             alpha=0.9)
 
-        nx.draw_networkx_labels(g, pos=pos,
+        nx.draw_networkx_labels(Gz, pos=pos,
                                 labels=dict(zip(nodelist,nodelist)),
                                 font_color='black')
 


### PR DESCRIPTION
Alterei a geração de imagem para receber o grafo em si e não mais a categoria.

Assim é possível gerar imagens de grafos contendo diferentes categorias de arestas.

Implementei a alteração no arquivo da função e já atualizei os exemplos com os parâmetros corretos para a função. 